### PR TITLE
Ability to log in using Facebook, Google and Github

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,10 @@ gem 'gravtastic'
 gem 'pickadate-rails'
 gem 'jquery-turbolinks'
 gem 'gon'
+
+# Oauth base Gem, this group has facebook, google oauth gems,
+gem 'omniauth'
+gem 'omniauth-facebook'
+gem 'omniauth-github'
+gem 'omniauth-google-oauth2', git: 'https://github.com/zquestz/omniauth-google-oauth2.git'
+gem 'omniauth-oauth2', '~> 1.3.1' # Don't touch that unless you don't want Google omniauth to work!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,16 @@ GIT
       ransack (~> 1.3)
       sass-rails
 
+GIT
+  remote: https://github.com/zquestz/omniauth-google-oauth2.git
+  revision: 4587b25d5611d6446aa8690966c38f099197dcf7
+  specs:
+    omniauth-google-oauth2 (0.4.1)
+      jwt (~> 1.5.2)
+      multi_json (~> 1.3)
+      omniauth (>= 1.1.1)
+      omniauth-oauth2 (>= 1.3.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -115,6 +125,8 @@ GEM
       railties (>= 3.0.0)
     faker (1.6.1)
       i18n (~> 0.5)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     figaro (1.1.1)
       thor (~> 0.14)
     font-awesome-rails (4.5.0.1)
@@ -136,6 +148,7 @@ GEM
     has_scope (0.6.0)
       actionpack (>= 3.2, < 5)
       activesupport (>= 3.2, < 5)
+    hashie (3.4.6)
     hpricot (0.8.6)
     html2slim (0.2.0)
       hpricot
@@ -158,6 +171,7 @@ GEM
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     json (1.8.3)
+    jwt (1.5.6)
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -182,8 +196,27 @@ GEM
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.2)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
+    oauth2 (1.2.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    omniauth (1.3.1)
+      hashie (>= 1.2, < 4)
+      rack (>= 1.0, < 3)
+    omniauth-facebook (4.0.0)
+      omniauth-oauth2 (~> 1.2)
+    omniauth-github (1.1.2)
+      omniauth (~> 1.0)
+      omniauth-oauth2 (~> 1.1)
+    omniauth-oauth2 (1.3.1)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
     orm_adapter (0.5.0)
     parser (2.3.0.2)
       ast (~> 2.2)
@@ -356,6 +389,11 @@ DEPENDENCIES
   mailcatcher
   maskedinput-rails
   mocha
+  omniauth
+  omniauth-facebook
+  omniauth-github
+  omniauth-google-oauth2!
+  omniauth-oauth2 (~> 1.3.1)
   pg
   pickadate-rails
   pry
@@ -373,5 +411,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
+RUBY VERSION
+   ruby 2.2.3p173
+
 BUNDLED WITH
-   1.11.2
+   1.13.5

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -5,20 +5,21 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # You should also create an action method in this controller like this:
   # def twitter
   # end
+  skip_before_action :verify_authenticity_token
 
   def facebook
-     generic_callback( 'facebook' )
-   end
+    generic_callback( 'facebook' )
+  end
 
-  #  def google_oauth2
-  #    generic_callback( 'google_oauth2' )
-  #  end
+  def google
+    generic_callback( 'google' )
+  end
 
-   def google
-     generic_callback( 'google' )
-   end
+  def github
+    generic_callback( 'github' )
+  end
 
-   def generic_callback( provider )
+  def generic_callback( provider )
     @user = User.from_omniauth(request.env["omniauth.auth"])
      if @user.persisted?
        sign_in_and_redirect @user, event: :authentication

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,0 +1,51 @@
+class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  def facebook
+     generic_callback( 'facebook' )
+   end
+
+  #  def google_oauth2
+  #    generic_callback( 'google_oauth2' )
+  #  end
+
+   def google
+     generic_callback( 'google' )
+   end
+
+   def generic_callback( provider )
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+     if @user.persisted?
+       sign_in_and_redirect @user, event: :authentication
+       set_flash_message(:notice, :success, kind: provider.capitalize) if is_navigational_format?
+     else
+       session["devise.#{provider}_data"] = env["omniauth.auth"]
+       redirect_to new_user_registration_url
+     end
+  end
+
+  # More info at:
+  # https://github.com/plataformatec/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,13 @@ class User < ActiveRecord::Base
   validates_length_of :first_name, :last_name, minimum: 2, maximum: 35, allow_blank: false
   validates_length_of :email, minimum: 5, maximum: 35, allow_blank: false
 
+  before_validation do
+    if uid.blank?
+      self.uid = email
+      self.provider = "email"
+      self.status = true
+    end
+  end
   # getting user friendly url
   def to_param
     "#{id} #{first_name} #{last_name}".parameterize
@@ -56,12 +63,8 @@ class User < ActiveRecord::Base
         user.uid = auth.uid
         user.email = auth.info.email
         user.password = Devise.friendly_token[0,20]
-        user.name = auth.info.name
-        user.image = auth.info.image
-        user.gender = getGender(auth.extra.raw_info.gender.to_s)
-        user.nickname = auth.extra.raw_info.username
-        user.status = true
-        user.confirmed_at = Time.now
+        user.first_name = auth.info.first_name
+        user.last_name = auth.info.last_name
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ActiveRecord::Base
   has_many :events, through: :user_events
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :omniauthable, :omniauth_providers => [:facebook, :google]
+         :omniauthable, :omniauth_providers => [:facebook, :google, :github]
 
   validates :email, uniqueness: true
   validates_length_of :first_name, :last_name, minimum: 2, maximum: 35, allow_blank: false
@@ -63,8 +63,11 @@ class User < ActiveRecord::Base
         user.uid = auth.uid
         user.email = auth.info.email
         user.password = Devise.friendly_token[0,20]
-        user.first_name = auth.info.first_name
-        user.last_name = auth.info.last_name
+        user.first_name = (auth.info.key?(:first_name) ? auth.info.first_name : auth.info.name.split[0])
+        lastname = auth.info.name.split(" ")
+        lastname.delete(user.first_name)
+        lastname = lastname.join(" ")
+        user.last_name = (auth.info.key?(:last_name) ? auth.info.last_name : lastname)
       end
     end
   end

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,8 @@
+<span style="color:#8A8A8A;font-size:12px;">Sign in with:</span>&nbsp;&nbsp;
+<!--<ul class="login-navigation">-->
+  <%- if devise_mapping.omniauthable? %>
+    <%- resource_class.omniauth_providers.each do |provider| %>
+        <%= link_to provider, omniauth_authorize_path(resource_name, provider)%>
+    <% end -%>
+  <% end -%>
+<!--</ul>-->

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -34,7 +34,7 @@ Devise.setup do |config|
   config.omniauth :google_oauth2, Figaro.env.google_client_id, Figaro.env.google_client_secret,
   {
     :name => "google",
-    :scope => "email,profile",
+    :scope => "userinfo.email, email, profile",
     :prompt => "consent",
     :image_aspect_ratio => "square",
     :image_size => 50,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -25,6 +25,20 @@ Devise.setup do |config|
   # ==> Configuration for :recoverable
   config.reset_password_within = 6.hours
 
+  config.omniauth :facebook, Figaro.env.facebook_key, Figaro.env.facebook_secret,
+  {
+    :image_size => { :width => 400, :height => 400},
+    :info_fields => 'email,name,first_name,last_name,gender'
+  }
+
+  config.omniauth :google_oauth2, Figaro.env.google_client_id, Figaro.env.google_client_secret,
+  {
+    :name => "google",
+    :scope => "email,profile,offline",
+    :prompt => "consent",
+    :image_aspect_ratio => "square",
+    :image_size => 50,
+  }
 
   config.sign_out_via = :delete
   config.secret_key = '148392097cf1a1b8e0f791dc70b3f519859bc98e94471c0d976183563eb94227dcc9ed088ad3f0e5bb7b2f392c80c0dd0fc187f2ec8ef61e2531abe84da0f07f'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -34,11 +34,12 @@ Devise.setup do |config|
   config.omniauth :google_oauth2, Figaro.env.google_client_id, Figaro.env.google_client_secret,
   {
     :name => "google",
-    :scope => "email,profile,offline",
+    :scope => "email,profile",
     :prompt => "consent",
     :image_aspect_ratio => "square",
     :image_size => 50,
   }
+  config.omniauth :github, Figaro.env.github_key, Figaro.env.github_secret, scope: "user:email"
 
   config.sign_out_via = :delete
   config.secret_key = '148392097cf1a1b8e0f791dc70b3f519859bc98e94471c0d976183563eb94227dcc9ed088ad3f0e5bb7b2f392c80c0dd0fc187f2ec8ef61e2531abe84da0f07f'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   ActiveAdmin.routes(self)
-  devise_for :users
+  devise_for :users, controllers: {
+    omniauth_callbacks: 'omniauth_callbacks'
+  }
 
   get 'users/search' => 'users#search'
 

--- a/db/migrate/20161015210121_add_omniauth_fields_to_users.rb
+++ b/db/migrate/20161015210121_add_omniauth_fields_to_users.rb
@@ -1,0 +1,6 @@
+class AddOmniauthFieldsToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :provider, :string, :null => false
+    add_column :users, :uid, :string, :null=>false, :default=>""
+  end
+end

--- a/db/migrate/20161015210121_add_omniauth_fields_to_users.rb
+++ b/db/migrate/20161015210121_add_omniauth_fields_to_users.rb
@@ -1,6 +1,7 @@
 class AddOmniauthFieldsToUsers < ActiveRecord::Migration
   def change
-    add_column :users, :provider, :string, :null => false
+    add_column :users, :provider, :string, :null => false, :default=>"email"
     add_column :users, :uid, :string, :null=>false, :default=>""
+    add_index :users, [:uid, :provider],     :unique => true
   end
 end


### PR DESCRIPTION
Completes Issue #55 

To get this up and running, create applications on facebook developers, google developers and github applications and set the appropriate keys:

> facebook_key
> facebook_secret
> 
> google_client_id
> google_client_secret
> 
> github_key
> github_secret

as Environment or Figaro variables. 

NOTE: Enable Google+ API in Google API manager for authentication to happen.
