### PR TITLE
Fixed failing user model spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'jquery-rails'
 gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
+gem 'paperclip'
 
 group :production do
   gem 'rails_12factor'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,9 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :validatable
 
   validates :email, uniqueness: true
-  validates_length_of :first_name, :last_name, minimum: 2, maximum: 35, allow_blank: false
+  validates :first_name, :last_name, presence: true
+  validates :password_confirmation, presence: true, on: :create
+  validates_length_of :first_name, :last_name, minimum: 2, maximum: 35
   validates_length_of :email, minimum: 5, maximum: 35, allow_blank: false
 
   # getting user friendly url


### PR DESCRIPTION
While trying to get the project started on my machine, my migrations were stopping due to paperclip not being installed. I updated the Gemfile with `paperclip`.

Also, I noticed that the specs were failing. `allow_blank` didn't seem to work with `validates_length_of` so I added a `presence` validation instead. I also found that the user edit page was not saving the user due to password_confirmation being blank. I added a validation for password_confirmation on create only. 
